### PR TITLE
Fixes/adjustments after <video> remove

### DIFF
--- a/www/.vuepress/theme/components/oj-video.vue
+++ b/www/.vuepress/theme/components/oj-video.vue
@@ -68,11 +68,11 @@ export default {
 	},
 
 	mounted() {
-		clearInterval(window.updateProgress)
-		const { video } = this.$el.children
-		window.updateProgress = setInterval((() => {
-			if (video.paused) { return } else { return this.currentTime = video.currentTime }
-		}), 150
+		// clearInterval(window.updateProgress)
+		// const { video } = this.$el.children
+		// window.updateProgress = setInterval((() => {
+		// 	if (video.paused) { return } else { return this.currentTime = video.currentTime }
+		// }), 150
 		)
 	},
 

--- a/www/.vuepress/theme/components/oj-video.vue
+++ b/www/.vuepress/theme/components/oj-video.vue
@@ -73,7 +73,7 @@ export default {
 		// window.updateProgress = setInterval((() => {
 		// 	if (video.paused) { return } else { return this.currentTime = video.currentTime }
 		// }), 150
-		)
+		// )
 	},
 
 	destroyed() {

--- a/www/.vuepress/theme/layouts/Home.vue
+++ b/www/.vuepress/theme/layouts/Home.vue
@@ -57,11 +57,11 @@ export default {
 main
 	margin-top 0
 	transition margin-top .5s ease
-.video-bg
-	main
-		margin-top calc(100vh - 5.5rem)
-		+above(0, true, null, 'portrait')
-			margin-top 75vh
+// .video-bg
+//	main
+//		margin-top calc(100vh - 5.5rem)
+//		+above(0, true, null, 'portrait')
+//			margin-top 75vh
 .intro
 	margin 6rem auto 0 auto
 	.title


### PR DESCRIPTION
- błędy w konsoli przez odwoływanie się do `<video>`, którego już nie ma
- niepotrzebny po usunięciu `<video>` margines, który wygląda jakby strona się rozjechała

<img width="411" height="849" alt="image" src="https://github.com/user-attachments/assets/07a11ac4-2a62-440c-acec-49277d96102f" />

<img width="467" height="615" alt="image" src="https://github.com/user-attachments/assets/5ccb57b3-f962-4aed-9a74-f1eeb9944c1b" />

