### PR TITLE
fix: zamknij menu po nawigacji i wyczysc body class przy destroy

### DIFF
--- a/www/.vuepress/theme/components/oj-menu.vue
+++ b/www/.vuepress/theme/components/oj-menu.vue
@@ -34,6 +34,9 @@ export default {
 	methods: {
 		toggleMenu(force){
 			return this.mobileMenu = !this.mobileMenu
+		},
+		closeMenu(){
+			this.mobileMenu = false
 		}
 	},
 	watch: {
@@ -43,7 +46,13 @@ export default {
 			} else {
 				return document.body.classList.remove('menu-on')
 			}
+		},
+		$route(){
+			this.closeMenu()
 		}
+	},
+	beforeDestroy(){
+		document.body.classList.remove('menu-on')
 	}
 }
 </script>


### PR DESCRIPTION
- Dodano watcher na \$route zamykajacy menu po kliknieciu linku nawigacyjnego
- Dodano beforeDestroy czyszczacy klase menu-on z body, zapobiegajac niewidocznej warstwie blokujacej scroll

https://claude.ai/code/session_01EbYZY63e7v1cz5VfpphkE6