### PR TITLE
fix(stopka): końcowy slash w linkach — koniec zbędnych przekierowań 301

### DIFF
--- a/www/.vuepress/themeConfig.json
+++ b/www/.vuepress/themeConfig.json
@@ -74,33 +74,33 @@
   "links": {
     "pl": [
       {
-        "to": "/partnerstwo",
+        "to": "/partnerstwo/",
         "title": "Partnerstwo"
       },
       {
-        "to": "/statut",
+        "to": "/statut/",
         "title": "Statut"
       },
       {
-        "to": "/regulamin",
+        "to": "/regulamin/",
         "title": "Regulamin"
       },
       {
-        "to": "/sprawozdania",
+        "to": "/sprawozdania/",
         "title": "Sprawozdania"
       },
       {
-        "to": "/regulamin-darowizn",
+        "to": "/regulamin-darowizn/",
         "title": "Regulamin Darowizn"
       },
       {
-        "to": "/polityka-prywatnosci",
+        "to": "/polityka-prywatnosci/",
         "title": "Polityka Prywatności"
       }
     ],
     "en": [
       {
-        "to": "/en/privacy-policy",
+        "to": "/en/privacy-policy/",
         "title": "Privacy Policy"
       }
     ]


### PR DESCRIPTION
Trzeci PR sesji 4. `ARCHITEKTURA.md §5.1`.

## Problem
Menu główne używa adresów **ze slashem** (6/6), stopka **bez** (0/6). Netlify przekierowuje `/statut` → `/statut/` (301), więc **każde kliknięcie w stopce kosztowało dodatkowy przeskok** — wolniej dla użytkownika i niepotrzebny sygnał dla wyszukiwarek.

Zweryfikowane na produkcji: `curl -I https://jazdow.pl/statut` → `301 → /statut/`.

## Co zmienia
7 linków w `themeConfig.json` (6 PL + 1 EN) dostaje końcowy slash — forma kanoniczna serwisu:
`/partnerstwo/`, `/statut/`, `/regulamin/`, `/sprawozdania/`, `/regulamin-darowizn/`, `/polityka-prywatnosci/`, `/en/privacy-policy/`

## Jak zweryfikować
1. `yarn build` — OK.
2. W `dist/index.html` stopka renderuje `href="/statut/"` itd. — potwierdzone dla wszystkich 6.
3. Po wdrożeniu klik w stopkę trafia od razu w cel, bez przeskoku 301.

## Co może się zepsuć
Nic — **żaden adres strony się nie zmienia**, zmienia się tylko forma linku. Stare adresy bez slasha nadal działają (Netlify przekierowuje), więc zewnętrzne linki są bezpieczne.