### PR TITLE
fix(treść): drobne poprawki redakcyjne (R6, R8, R13, R14)

### DIFF
--- a/www/co-robimy.md
+++ b/www/co-robimy.md
@@ -68,9 +68,9 @@ Opiekunki i Opiekunowie Czytelni: Hania, Klaudia, Karola, Magda, Mikołaj, Nemo,
 
 ## Plakaty zbiorcze
 
-[![Sierpień 2026](/plakaty/2026_08.png "Sierpień 2026")](https://jazdow.pl/plakaty/2026_08.png)
+[![Sierpień 2026](/plakaty/2026_08-small.jpg "Sierpień 2026")](https://jazdow.pl/plakaty/2026_08.png)
 
-[![Lipiec 2026](/plakaty/2026_07.png "Lipiec 2026")](https://jazdow.pl/plakaty/2026_07.png)
+[![Lipiec 2026](/plakaty/2026_07-small.jpg "Lipiec 2026")](https://jazdow.pl/plakaty/2026_07.png)
 
 [![Czerwiec 2026](/plakaty/2026_06-small.jpg "Czerwiec 2026")](https://jazdow.pl/plakaty/2026_06.png)
 

--- a/www/domki/3-20.md
+++ b/www/domki/3-20.md
@@ -1,6 +1,12 @@
 ---
 permalink: domki/3-20
-title: Ambsada Muzyki Tradycyjnej
+title: Ambasada Muzyki Tradycyjnej
 layout: Houses
 address: Jazdów 3/20, Warszawa
 ---
+
+Opis tego domku jest w przygotowaniu.
+
+Jeśli działasz w tym domku i chcesz uzupełnić opis — napisz na [wolny@jazdow.pl](mailto:wolny@jazdow.pl).
+
+[Wróć do mapy Osiedla Jazdów](/mapa/)

--- a/www/sprawozdania.md
+++ b/www/sprawozdania.md
@@ -8,48 +8,48 @@ generic: true
 ---
 ## 2025
 
-### [sprawozdanie merytoryczne 2025](/sprawozdania/2025_sprawozdanie_merytoryczne_43147.pdf)
-### [wprowadzenie do sprawozdania finansowego 2025](/sprawozdania/2025_wprowadzenie_do_sprawozdania_finansowego_81481.pdf)
-### [bilans 2025](/sprawozdania/2025_bilans_81481.pdf)
-### [rachunek zysków i strat 2025](/sprawozdania/2025_rachunek_zyskow_i_strat_81480.pdf)
-### [informacja dodatkowa 2025](/sprawozdania/2025_informacja_dodatkowa_81482.pdf)
+- [sprawozdanie merytoryczne 2025](/sprawozdania/2025_sprawozdanie_merytoryczne_43147.pdf)
+- [wprowadzenie do sprawozdania finansowego 2025](/sprawozdania/2025_wprowadzenie_do_sprawozdania_finansowego_81481.pdf)
+- [bilans 2025](/sprawozdania/2025_bilans_81481.pdf)
+- [rachunek zysków i strat 2025](/sprawozdania/2025_rachunek_zyskow_i_strat_81480.pdf)
+- [informacja dodatkowa 2025](/sprawozdania/2025_informacja_dodatkowa_81482.pdf)
 
 ## 2024
 
-### [sprawozdanie merytoryczne 2024](/sprawozdania/2024_sprawozdanie_merytoryczne_36087.pdf)
-### [wprowadzenie do sprawozdania finansowego 2024](/sprawozdania/2024_wprowadzenie_do_sprawozdania_finansowego_70470.pdf)
-### [bilans 2024](/sprawozdania/2024_bilans_70470.pdf)
-### [rachunek zysków i strat 2024](/sprawozdania/2024_rachunek_zyskow_i_strat_70469.pdf)
-### [informacja dodatkowa 2024](/sprawozdania/2024_informacja_dodatkowa_70471.pdf)
+- [sprawozdanie merytoryczne 2024](/sprawozdania/2024_sprawozdanie_merytoryczne_36087.pdf)
+- [wprowadzenie do sprawozdania finansowego 2024](/sprawozdania/2024_wprowadzenie_do_sprawozdania_finansowego_70470.pdf)
+- [bilans 2024](/sprawozdania/2024_bilans_70470.pdf)
+- [rachunek zysków i strat 2024](/sprawozdania/2024_rachunek_zyskow_i_strat_70469.pdf)
+- [informacja dodatkowa 2024](/sprawozdania/2024_informacja_dodatkowa_70471.pdf)
 
 ## 2023
 
-### [bilans i rachunek 2023](/sprawozdania/2023_finansowe.pdf)
-### [informacje uzupełniające 2023](/sprawozdania/2023_dodatkowe.pdf)
+- [bilans i rachunek 2023](/sprawozdania/2023_finansowe.pdf)
+- [informacje uzupełniające 2023](/sprawozdania/2023_dodatkowe.pdf)
 
 ## 2022
 
-### [bilans i rachunek 2022](/sprawozdania/2022_finansowe.pdf)
-### [informacje uzupełniające 2022](/sprawozdania/2022_dodatkowe.pdf)
+- [bilans i rachunek 2022](/sprawozdania/2022_finansowe.pdf)
+- [informacje uzupełniające 2022](/sprawozdania/2022_dodatkowe.pdf)
 
 ## 2021
 
-### [bilans i rachunek 2021](/sprawozdania/2021_finansowe.pdf)
-### [informacje uzupełniające 2021](/sprawozdania/2021_dodatkowe.pdf)
+- [bilans i rachunek 2021](/sprawozdania/2021_finansowe.pdf)
+- [informacje uzupełniające 2021](/sprawozdania/2021_dodatkowe.pdf)
 
 ## 2020
 
-### [bilans i rachunek 2020](/sprawozdania/2020_finansowe.pdf)
-### [informacje uzupełniające 2020](/sprawozdania/2020_dodatkowe.pdf)
+- [bilans i rachunek 2020](/sprawozdania/2020_finansowe.pdf)
+- [informacje uzupełniające 2020](/sprawozdania/2020_dodatkowe.pdf)
 
 ## 2019
 
-### [sprawozdanie merytoryczne 2019](/sprawozdania/2019_merytoryczne.pdf)
-### [bilans i rachunek 2019](/sprawozdania/2019_finansowe.pdf)
-### [informacje uzupełniające 2019](/sprawozdania/2019_dodatkowe.pdf)
+- [sprawozdanie merytoryczne 2019](/sprawozdania/2019_merytoryczne.pdf)
+- [bilans i rachunek 2019](/sprawozdania/2019_finansowe.pdf)
+- [informacje uzupełniające 2019](/sprawozdania/2019_dodatkowe.pdf)
 
 ## 2018
 
-### [sprawozdanie merytoryczne 2018](/sprawozdania/2018_merytoryczne.pdf)
-### [bilans i rachunek 2018](/sprawozdania/2018_finansowe.pdf)
-### [informacje uzupełniające 2018](/sprawozdania/2018_dodatkowe.pdf)
+- [sprawozdanie merytoryczne 2018](/sprawozdania/2018_merytoryczne.pdf)
+- [bilans i rachunek 2018](/sprawozdania/2018_finansowe.pdf)
+- [informacje uzupełniające 2018](/sprawozdania/2018_dodatkowe.pdf)

--- a/www/wesprzyj.md
+++ b/www/wesprzyj.md
@@ -6,12 +6,6 @@ generic: true
 ---
 Wolny Jazdów utrzymuje się w głównie z dobrowolnych zbiórek swoich członków, gości i fanów. Jeśli podoba Ci się to co robimy i chcesz pomóc nam dalej chronić i rozwijać Osiedle Jazdów, to możesz to zrobić na kilka sposobów.
 
-### Patronite.pl/jazdow - stały patronat
-
-Dołącz do społeczności Patronite i korzystaj z przestrzeni domku fińskiego na stałe! Dołączając jesteś także na bieżąco z wszystkimi wydarzeniami Wolnego Jazdowa.
-
-➡️ [patronite.pl/jazdow](https://patronite.pl/jazdow)
-
 ## Bądź na bieżąco
 
 Zapraszamy do:


### PR DESCRIPTION
Czwarty PR sesji 4. Cztery poprawki z listy redakcyjnej `ARCHITEKTURA.md §6` — te, które są jednoznaczne i **nie zmieniają treści merytorycznej**.

| # | Gdzie | Co |
|---|---|---|
| **R6** | `wesprzyj.md` | Nagłówek „Patronite.pl/jazdow — stały patronat" występował **dwa razy**, z identycznym akapitem. Usunięty ten osierocony (H3 stojący **przed** pierwszym H2); został poprawnie zagnieżdżony pod „Wesprzyj finansowo". |
| **R8** | `sprawozdania.md` | 24 linki do PDF-ów były **nagłówkami H3**. Zamienione na listę. Konspekt strony: **32 nagłówki → 8** (lata) **+ 24 pozycje listy**. Strona ma 124 słowa — 32 nagłówki czyniły ją nieczytelną dla czytników ekranu. |
| **R13** | `domki/3-20.md` | Literówka w tytule: „Ambsada" → **„Ambasada"** Muzyki Tradycyjnej. Strona była **całkiem pusta** — dodana treść zastępcza, jak w szablonach z #201. |
| **R14** | `co-robimy.md` | Plakaty 2026_08 i 2026_07 wyświetlały się jako **pełne PNG (~700 KB każdy)**, pozostałe 26 jako miniatury. Ujednolicone na miniatury; link nadal prowadzi do pełnej wersji. |

## Jak zweryfikować
1. `yarn build` — OK.
2. `dist/sprawozdania/index.html`: `<h2>` = 8, `<h3>` = **0**, `<li>` = 24.
3. Wszystkie **24 pliki PDF** ze sprawozdań sprawdzone — komplet istnieje, żaden link nie jest martwy.
4. `wesprzyj.md`: jedno wystąpienie nagłówka Patronite.

## Co może się zepsuć
- **Kotwice (`#`) zmienione na `/sprawozdania/`** — H3 generowały kotwice typu `#bilans-2025`, lista ich nie ma. Jeśli ktoś linkował bezpośrednio do konkretnego sprawozdania, taki link przestanie działać. Uznałem to za akceptowalne (mało prawdopodobne, a poprawność konspektu jest ważniejsza) — powiedz, jeśli wolisz zachować kotwice.
- Reszta bez ryzyka: literówka, duplikat i rozmiar obrazka nie wpływają na adresy ani treść merytoryczną.

Pozostałe sugestie redakcyjne (R1–R5, R7, R9–R12) wymagają decyzji treściowych — **nie są w tym PR**.