### PR TITLE
feat: wymagania Netlify Open Source — Code of Conduct, plik LICENSE, link do Netlify

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,52 @@
+# Kodeks postępowania / Code of Conduct
+
+## Polityka Ochrony Dobrostanu
+
+Zasady postępowania obowiązujące w Związku Stowarzyszeń Partnerstwo Otwarty Jazdów
+określa **Polityka Ochrony Dobrostanu** — polityka wewnętrzna dotycząca przeciwdziałania
+przemocy, dyskryminacji, molestowaniu seksualnemu i mobbingowi, przyjęta 26 września 2024 r.
+
+**Pełny tekst:**
+
+- na stronie: https://jazdow.pl/polityka-ochrony-dobrostanu/
+- w repozytorium: [`www/polityka-ochrony-dobrostanu.md`](www/polityka-ochrony-dobrostanu.md)
+
+### W skrócie
+
+- Polityka obowiązuje wszystkie osoby zatrudnione w POJ oraz osoby współpracujące
+  (wolontariat, staż, praktyki, umowy cywilnoprawne, B2B).
+- Nie ma przyzwolenia na przemoc, dyskryminację, molestowanie seksualne, mobbing
+  ani inne niepożądane zachowania — także w kontaktach wokół tego projektu.
+- Zasada równego traktowania obejmuje m.in. płeć, wiek, niepełnosprawność, stan zdrowia,
+  kolor skóry, narodowość, pochodzenie etniczne, religię i bezwyznaniowość, przekonania
+  polityczne, przynależność związkową, orientację seksualną, tożsamość płciową i status
+  rodzinny.
+- Skorzystanie ze skargi nie może być podstawą niekorzystnego traktowania osoby
+  zgłaszającej ani osób ją wspierających.
+
+### Zgłoszenia
+
+Skargę składa się do Osoby Zaufania: **[zaufanie@jazdow.pl](mailto:zaufanie@jazdow.pl)**.
+Jeżeli zgłoszenie dotyczy Osoby Zaufania — do jednego z członków lub członkiń Zarządu POJ.
+Tryb postępowania, skład Komisji i terminy opisuje rozdział IV Polityki.
+
+## English
+
+The code of conduct for this project is the **Polityka Ochrony Dobrostanu** (Welfare
+Protection Policy) of Partnerstwo Otwarty Jazdów — the organisation's internal policy
+against violence, discrimination, sexual harassment and workplace bullying, adopted on
+26 September 2024. It applies to everyone employed by or cooperating with the organisation,
+including volunteers and contributors.
+
+Full text (Polish): https://jazdow.pl/polityka-ochrony-dobrostanu/
+
+Reports go to the Person of Trust at **zaufanie@jazdow.pl**; if the report concerns that
+person, to a member of the board. Retaliation against anyone who files a report, or who
+supports them, is prohibited.
+
+---
+
+*Uwaga dla osób redagujących: pełny tekst Polityki jest utrzymywany w pliku
+[`www/polityka-ochrony-dobrostanu.md`](www/polityka-ochrony-dobrostanu.md) (publikowany na
+stronie). Zmiany w Polityce wprowadza się tam — ten plik zawiera wyłącznie streszczenie
+i odesłania.*

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017-2026 Partnerstwo Otwarty Jazdów Związek Stowarzyszeń
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -15,29 +15,9 @@ Dotyczy: motywu VuePress (`www/.vuepress/theme/`), konfiguracji (`www/.vuepress/
 `themeConfig.json`), skryptów (`scripts/`), plików budowania (`package.json`, `netlify.toml`)
 oraz pozostałego kodu w tym repozytorium.
 
-```
-MIT License
-
-Copyright (c) 2017-2026 Partnerstwo Otwarty Jazdów Związek Stowarzyszeń
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-```
+Kod jest dostępny na [licencji MIT](https://opensource.org/license/mit) — zatwierdzonej
+przez Open Source Initiative. Pełny tekst licencji wraz z notą o prawach autorskich
+znajduje się w pliku [`LICENSE`](LICENSE).
 
 ## 2. Treści — licencja CC BY-NC-SA 4.0
 

--- a/README.md
+++ b/README.md
@@ -12,9 +12,17 @@ Vue components are written using `Pug` and `stylus`
 
 The markdown content can be edited using [Netlify CMS](https://www.netlifycms.org/)
 
+## Code of Conduct
+
+The project follows the organisation's **Polityka Ochrony Dobrostanu** (Welfare Protection
+Policy) — see [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md), full text at
+[jazdow.pl/polityka-ochrony-dobrostanu](https://jazdow.pl/polityka-ochrony-dobrostanu/).
+Reports go to zaufanie@jazdow.pl.
+
 ## License
 
 This repository is dual-licensed — see [LICENSE.md](LICENSE.md) for the full terms.
+The MIT text for the code is in [LICENSE](LICENSE).
 
 - **Source code** (theme, configuration, build scripts) — [MIT](LICENSE.md#1-kod-źródłowy--licencja-mit).
 - **Editorial content** (Markdown texts and the organisation's own informational graphics) —

--- a/www/.vuepress/theme/components/oj-footer.vue
+++ b/www/.vuepress/theme/components/oj-footer.vue
@@ -15,6 +15,8 @@ footer#oj-footer
 			router-link(v-for="link in $site.themeConfig.links[lang]" :key="link.to" :to="link.to") {{link.title}}
 		.license
 			a(:href="license.href", target="_blank", rel="noopener") {{license.title}}
+			span.separator(aria-hidden="true") ·
+			a(href="https://www.netlify.com", target="_blank", rel="noopener") This site is powered by Netlify
 </template>
 
 <script>
@@ -170,4 +172,9 @@ export default {
 		margin-top 1rem
 		a
 			font-size 1rem
+		.separator
+			display inline-block
+			margin 0 0.5rem
+			font-size 1rem
+			color $oj-green-free
 </style>

--- a/www/.vuepress/themeConfig.json
+++ b/www/.vuepress/themeConfig.json
@@ -96,12 +96,20 @@
       {
         "to": "/polityka-prywatnosci",
         "title": "Polityka Prywatności"
+      },
+      {
+        "to": "/polityka-ochrony-dobrostanu/",
+        "title": "Polityka Ochrony Dobrostanu"
       }
     ],
     "en": [
       {
         "to": "/en/privacy-policy",
         "title": "Privacy Policy"
+      },
+      {
+        "to": "/polityka-ochrony-dobrostanu/",
+        "title": "Code of Conduct (PL)"
       }
     ]
   },

--- a/www/polityka-ochrony-dobrostanu.md
+++ b/www/polityka-ochrony-dobrostanu.md
@@ -97,17 +97,17 @@ Celem wprowadzenia Polityki w POJ jest przeciwdziałanie przemocy, dyskryminacji
 
 ## Rozdział III. Obowiązki osób zatrudnionych
 
-### § 10.
+### § 9.
 
 Osoby zatrudnione zobowiązane są do powstrzymywania się od zachowań o charakterze przemocy, dyskryminacji, molestowania seksualnego i mobbingu, a także innych niepożądanych zachowań w miejscu pracy, wobec innych osób zatrudnionych i współpracujących, a także do kierowania się zasadą poszanowania godności w tych relacjach.
 
-### § 11.
+### § 10.
 
 Osoby wchodzące w skład kadry kierowniczej, mają obowiązek analizowania zachowań zarówno osób którymi zarządzają, jak również współpracujących, pod kątem przestrzegania zasady równego traktowania i przeciwdziałania mobbingowi, przemocy, oraz bezzwłocznego zgłoszenia Organizacji sytuacji, co do której mają podejrzenie, że mogą nosić znamiona przemocy, dyskryminacji, molestowania seksualnego, mobbingu i innych niepożądanych zachowań w miejscu pracy.
 
 ## Rozdział IV. Postępowanie wyjaśniające w sprawach o przemoc, dyskryminację, molestowanie seksualne i mobbing oraz tryb składania skarg
 
-### § 12.
+### § 11.
 
 1. Każda osoba zatrudniona, która uważa, że doświadczyła jakiejkolwiek formy przemocy, dyskryminacji, molestowania seksualnego, mobbingu lub innych niepożądanych zachowań w miejscu pracy, uprawniona jest do powiadomienia o tym fakcie Organizacji i złożenia skargi do osoby pełniącej funkcję Osoby Zaufania ([zaufanie@jazdow.pl](mailto:zaufanie@jazdow.pl)).
 2. Osobę Zaufania powołuje Zarząd POJ.
@@ -122,7 +122,7 @@ Osoby wchodzące w skład kadry kierowniczej, mają obowiązek analizowania zach
 
    b) poweźmie informacje od osoby zatrudnionej, której zgłaszane sytuacje noszące znamiona przemocy, dyskryminacji czy mobbingu bezpośrednio nie dotyczą, ale oceni je jako wysoce prawdopodobne.
 
-### § 13.
+### § 12.
 
 1. Osoba Zaufania, każdorazowo w terminie nie dłuższym niż 14 dni od wpłynięcia skargi zwołuje Komisję, której zadaniem jest obiektywne rozpatrzenie zgłoszenia, ustalenie czy zgłoszenie jest zasadne i czy wystąpiło lub występuje zjawisko przemocy, dyskryminacji, w tym molestowania seksualnego, mobbingu lub inne niepożądane zachowanie w miejscu pracy.
 2. W skład Komisji wchodzą następujące osoby:
@@ -145,9 +145,9 @@ Osoby wchodzące w skład kadry kierowniczej, mają obowiązek analizowania zach
 8. Oświadczenia, o których mowa w ust. 6-7, przechowuje się w aktach sprawy.
 9. Akta sprawy przechowuje Osoba Zaufania w miejscu, do którego nie mają dostępu inne osoby.
 
-### § 14.
+### § 13.
 
-1. Komisja rozpoczyna postępowanie bez zbędnej zwłoki, nie później niż w ciągu 14 dni od dnia zwołania. Komisja rozpatruje skargę i przygotowuje dokument „Protokół z przebiegu postępowania wraz z zaleceniami Komisji”, o którym mowa w § 15 w terminie nie dłuższym niż 21 dni. W szczególnie skomplikowanych sprawach Komisja może wydłużyć postępowanie maksymalnie o kolejne 14 dni, informując strony postępowania o przyczynach zaistniałego stanu rzeczy.
+1. Komisja rozpoczyna postępowanie bez zbędnej zwłoki, nie później niż w ciągu 14 dni od dnia zwołania. Komisja rozpatruje skargę i przygotowuje dokument „Protokół z przebiegu postępowania wraz z zaleceniami Komisji”, o którym mowa w § 14 w terminie nie dłuższym niż 21 dni. W szczególnie skomplikowanych sprawach Komisja może wydłużyć postępowanie maksymalnie o kolejne 14 dni, informując strony postępowania o przyczynach zaistniałego stanu rzeczy.
 2. Postępowanie przed Komisją prowadzone jest z poszanowaniem praw i ze szczególną dbałością o ochronę dóbr osobistych wszystkich uczestników postępowania.
 3. Komisja decyduje o zakończeniu postępowania bez rozstrzygnięcia merytorycznego, jeżeli:
 
@@ -164,7 +164,7 @@ Osoby wchodzące w skład kadry kierowniczej, mają obowiązek analizowania zach
 8. W przypadku odmowy złożenia podpisu przez którąkolwiek ze stron postępowania, fakt ten Komisja odnotowuje w protokole.
 9. W przypadku braku zwykłej większości głosów decyduje głos Przewodniczącego/ej Komisji.
 
-### § 15.
+### § 14.
 
 1. Z prac Komisji sporządzany jest dokument „Protokół z przebiegu postępowania wraz z zaleceniami Komisji”, który podpisują wszyscy członkowie/inie Komisji.
 2. Dokument, o którym mowa w ust. 1, sporządzony jest przez wyznaczonego przez Przewodniczącego/cą członka/inię Komisji i zawiera w szczególności:
@@ -181,29 +181,29 @@ Osoby wchodzące w skład kadry kierowniczej, mają obowiązek analizowania zach
 
    f) ewentualne rekomendacje w przedmiocie działań naprawczych do podjęcia przez Organizację, w tym mających zmierzać do skutecznej ochrony dobrostanu w Organizacji w przyszłości.
 
-   g) uzasadnienie nie podjęcia decyzji w przypadku zaistnienia okoliczności, o których mowa w § 14 ust. 3.
+   g) uzasadnienie nie podjęcia decyzji w przypadku zaistnienia okoliczności, o których mowa w § 13 ust. 3.
 
-2\. Niezwłocznie po zakończeniu postępowania Przewodniczący/a przekazuje zalecenia Komisji do Organizacji.
+3. Niezwłocznie po zakończeniu postępowania Przewodniczący/a przekazuje zalecenia Komisji do Organizacji.
 
-### § 16.
+### § 15.
 
 1. Organizacja, nie później niż w ciągu 14 dni od dnia przekazania przez Przewodniczącego/cą Komisji zaleceń Komisji, podejmuje działania zmierzające do wyeliminowania stwierdzonych nieprawidłowości i przeciwdziała ich powtórzeniu.
 2. W stosunku do osób, wobec których stwierdzono, że dopuściły się przemocy, dyskryminacji, molestowania seksualnego, mobbingu lub innych niepożądanych zachowań w miejscu pracy, Organizacja podejmuje działania dyscyplinujące, które może stanowić w szczególności zakończenie współpracy.
 3. Organizacja, stosując działania dyscyplinujące, kieruje się zasadą proporcjonalności wobec zaistniałego naruszenia.
 4. Przewodniczący/a Komisji jest odpowiedzialny/a za przygotowanie pisemnego komunikatu informującego strony o rezultacie zakończonego postępowania wyjaśniającego.
 
-### § 17.
+### § 16.
 
 1. Skorzystanie ze skargi nie może być podstawą niekorzystnego traktowania, a także nie może powodować jakichkolwiek negatywnych konsekwencji dla osoby zgłaszającej skargę oraz osoby/osób ją wspierającej/wspierających.
 2. Odpowiedzialności dyscyplinarnej podlegają osoby, które w ocenie Komisji pomawiają o przemoc, dyskryminację, w tym molestowanie seksualne czy mobbing.
 
 ## Rozdział V. Przepisy końcowe
 
-### § 18.
+### § 17.
 
 1. Organizacja może wprowadzać zmiany w przedmiotowej Polityce, po konsultacji projektu zmian z osobami zatrudnionymi, w terminie, który daje szansę zabrania głosu możliwie wszystkim osobom zatrudnionym.
 2. Organizacja uwzględnia propozycje osób zatrudnionych zgłoszone w trakcie konsultacji, o których mowa w ust. 1, jeśli można je uznać za obiektywnie racjonalne i wypełniające kryteria efektywnej prewencji antyprzemocowej, antydyskryminacyjnej lub antymobbingowej w miejscu pracy.
 
-### § 19.
+### § 18.
 
 Organizacja przy zatrudnianiu nowych osób zobowiązana jest do zapoznania ich z Polityką niezwłocznie po nawiązaniu stosunku pracy lub podjęciu współpracy.

--- a/www/polityka-ochrony-dobrostanu.md
+++ b/www/polityka-ochrony-dobrostanu.md
@@ -1,0 +1,209 @@
+---
+permalink: polityka-ochrony-dobrostanu
+title: Polityka Ochrony Dobrostanu
+tldr: Polityka wewnętrzna Związku Stowarzyszeń Partnerstwa Otwarty Jazdów dot. przeciwdziałania przemocy, dyskryminacji, molestowaniu seksualnemu i mobbingowi w Organizacji. Przyjęta 26 września 2024 r.
+generic: true
+---
+
+**Przyjęta: 26 września 2024 r.**
+
+Polityka wewnętrzna Związku Stowarzyszeń Partnerstwa Otwarty Jazdów dot. przeciwdziałania przemocy, dyskryminacji, molestowaniu seksualnemu i mobbingowi w Organizacji.
+
+*Związek Stowarzyszeń Partnerstwo Otwarty Jazdów jest organizacją, która zapewnia każdej osobie prawo do równego traktowania i niedyskryminacji. Nadrzędną wartością, jaką kieruje się POJ, jest poszanowanie godności wszystkich osób. POJ stara się zapewnić bezpiecznie i wolne od jakiejkolwiek formy przemocy środowisko działania.*
+
+*W POJ nie ma przyzwolenia na takie zachowania jak przemoc, mobbing i dyskryminacja w jakiejkolwiek postaci, a zasada równego traktowania i niedyskryminacji odnosi się do wszystkich obszarów i warunków zatrudnienia, w szczególności do rekrutacji, wynagradzania, dostępu do szkoleń i podnoszenia kwalifikacji, ocen i awansów oraz rozwiązywania stosunku pracy i współpracy.*
+
+*Mając na uwadze powyższe, POJ przyjmuje niniejszą Politykę i deklaruje stosowanie jej zapisów.*
+
+## Rozdział I. Przepisy ogólne
+
+### § 1.
+
+1. Niniejszy dokument, zwany dalej „Polityką” określa zasady przeciwdziałania zjawiskom przemocowym, dyskryminacji, molestowaniu seksualnemu i mobbingowi w *Związku Stowarzyszeń Partnerstwo Otwarty Jazdów* (dalej: POJ).
+2. Przepisy Polityki mają zastosowanie do wszystkich osób zatrudnionych w POJ oraz osób współpracujących z POJ.
+
+### § 2.
+
+Celem wprowadzenia Polityki w POJ jest przeciwdziałanie przemocy, dyskryminacji, molestowaniu seksualnemu, mobbingowi oraz innym niepożądanym zachowaniom.
+
+### § 3.
+
+1. Postanowienia Polityki nie naruszają prawa do sądu wynikającego z obowiązujących przepisów a osoby zatrudnione lub współpracując, które dopuściły się przemocy, mobbingu, dyskryminacji, molestowania seksualnego czy innych działań niepożądanych w organizacji, podlegają odpowiedzialności na zasadach określonych w przepisach prawa.
+2. Skorzystanie z procedury przewidzianej w Polityce nie pozbawia możliwości wystąpienia ze stosownym roszczeniem na drogę sądową na podstawie obowiązujących przepisów prawa.
+
+### § 4.
+
+1. Ilekroć w Polityce lub w postępowaniu wyjaśniającym toczącym się na podstawie Polityki jest mowa o:
+
+   a) **Dyskryminacji bezpośredniej** – rozumie się przez to sytuację, w której osoba w szczególności ze względu na płeć, wiek, niepełnosprawność, stan zdrowia, kolor skóry, narodowość, pochodzenie etniczne, religię, wyznanie, bezwyznaniowość, przekonania polityczne, przynależność związkową, orientację seksualną, tożsamość płciową, status rodzinny, formę, zakres i podstawę współpracy, jest traktowana mniej korzystnie niż jest, była lub byłaby traktowana inna osoba w porównywalnej sytuacji;
+
+   b) **Dyskryminacji pośredniej** – rozumie się przez to sytuację, w której dla osoby/osób w szczególności ze względu na płeć, wiek, niepełnosprawność, stan zdrowia, kolor skóry, narodowość, pochodzenie etniczne, religię, wyznanie, bezwyznaniowość, przekonania polityczne, przynależność związkową, orientację seksualną, tożsamość płciową, status rodzinny, formę, zakres i podstawę współpracy, na skutek pozornie neutralnego postanowienia, zastosowanego kryterium lub podjętego działania występują lub mogłyby wystąpić niekorzystne dysproporcje lub szczególnie niekorzystna dla niej/nich sytuacja, chyba że postanowienie, kryterium lub działanie jest obiektywnie uzasadnione ze względu na zgodny z prawem cel, który ma być osiągnięty, a środki służące osiągnięciu tego celu są właściwe i konieczne;
+
+   c) **Molestowaniu** – rozumie się przez to formę dyskryminacji, którą stanowi każde niepożądane zachowanie w stosunku do osoby w szczególności ze względu na płeć, wiek, niepełnosprawność, stan zdrowia, kolor skóry, narodowość, pochodzenie etniczne, religię, wyznanie, bezwyznaniowość, przekonania polityczne, przynależność związkową, orientację seksualną, tożsamość płciową, status rodzinny, formę, zakres i podstawę współpracy, którego celem lub skutkiem jest naruszenie godności osoby i stworzenie wobec niej zastraszającej, wrogiej, poniżającej, upokarzającej lub uwłaczającej atmosfery;
+
+   d) **Molestowaniu seksualnym** – rozumie się przez to formę dyskryminacji, którą stanowi każde niepożądane zachowanie o charakterze seksualnym wobec osoby lub odnoszące się do jej płci, którego celem lub skutkiem jest naruszenie godności, w szczególności przez stworzenie wobec osoby zastraszającej, wrogiej, poniżającej, upokarzającej lub uwłaczającej atmosfery; na zachowanie to mogą się składać fizyczne, werbalne lub pozawerbalne elementy;
+
+   e) **Nierównym traktowaniu** – rozumie się przez to gorsze traktowanie osoby lub grupy osób w zakresie nawiązania i rozwiązania stosunku pracy lub współpracy, warunków zatrudnienia, awansowania oraz dostępu do szkolenia w celu podnoszenia kwalifikacji zawodowych, a także mniej korzystne traktowanie wynikające z przeciwstawienia się zachowaniom dyskryminującym, oraz zachęcającym do takich zachowań i nakazującym takie zachowania;
+
+   f) **Mobbingu** – rozumie się przez to działania lub zachowania dotyczące osoby zatrudnionej lub skierowane przeciwko osobie zatrudnionej, polegające na uporczywym i długotrwałym nękaniu lub zastraszaniu osoby zatrudnionej, wywołujące u niej zaniżoną ocenę przydatności zawodowej, powodujące lub mające na celu poniżenie lub ośmieszenie, izolowanie go lub wyeliminowanie osoby z zespołu współpracowników; przy czym aby działania lub zachowania dotyczące osoby zatrudnionej mogły zostać uznane za mobbing, muszą one łącznie spełniać wszystkie powyższe warunki;
+
+   g) **Innych niepożądanych zachowaniach przemocowych w miejscu pracy** – należy rozumieć przez nie w szczególności:
+
+   - nierówne traktowanie osób zatrudnionych i współpracujących,
+   - upokarzające postępowanie dyscyplinarne,
+   - terror telefoniczny (np. uporczywe telefony przełożonego po godzinach pracy, w sprawach, które obiektywnie nie są pilne),
+   - listy i e-maile zawierające zwroty bezpośrednie powszechnie uważane za obraźliwe, obelżywe,
+   - zastraszanie,
+   - nękanie,
+   - przydzielanie zadań nie związanych z pracą,
+   - publiczne dyskredytowanie wiedzy, umiejętności, kompetencji,
+   - publiczne i przejaskrawione komentowanie wyglądu osoby zatrudnionej bądź jej cech charakteru i stylu bycia,
+   - rozpowszechnianie nieprawdziwych informacji o przebiegu pracy zawodowej,
+   - przemoc fizyczną,
+   - działania odwetowe wobec osób zgłaszających nieprawidłowości.
+
+   h) **Komisji** – rozumie się przez to Komisję ds. Przeciwdziałania Przemocy w POJ;
+
+   i) **Organizacji** – rozumie się przez to POJ;
+
+   j) **Osobie zatrudnionej** – rozumie się przez to osobę zatrudnioną w POJ na podstawie umowy o pracę lub na podstawie umów cywilnoprawnych, tj. np.: umowa zlecenie, umowa o dzieło, umowa o współpracy czy umowa B2B;
+
+   k) **Osobie współpracującej** – rozumie się przez to osoby, które łączy z POJ inna niż zatrudnienie forma współpracy, tj. jak np.: praktyki zawodowe, staż, wolontariat czy świadczenie usług.
+
+## Rozdział II. Obowiązki Organizacji
+
+### § 5.
+
+1. Relacje pomiędzy Organizacją a osobami zatrudnionymi oraz osobami współpracującymi oparte są na zasadzie szacunku i tolerancji oraz poszanowaniu godności osobistej.
+2. Organizacja, która poweźmie informację na temat niewłaściwych zachowań osób zatrudnionych i/lub współpracujących, które mogą prowadzić do naruszenia godności osobistej, zobowiązana jest do powzięcia adekwatnych działań zaradczych, mających na celu wyeliminowanie naruszeń.
+
+### § 6.
+
+1. Wszystkie decyzje Organizacji, dotyczące zatrudniania, awansowania, kierowania na szkolenia podnoszące kwalifikacje, warunków zatrudnienia, w tym w szczególności odnośnie kształtowania wynagrodzenia osób zatrudnionych są motywowane przede wszystkim obiektywną oceną ich wyników w pracy, umiejętności i kompetencji oraz doświadczenia zawodowego.
+
+### § 7.
+
+1. Organizacja zobowiązuje się wobec osób zatrudnionych do jednakowego wynagradzania za pracę jednakową lub pracę jednakowej wartości w szczególności bez względu na płeć, wiek, niepełnosprawność, stan zdrowia, kolor skóry, narodowość, pochodzenie etniczne, religię, wyznanie, bezwyznaniowość, przekonania polityczne, przynależność związkową, orientację seksualną, tożsamość płciową, status rodzinny, formę, zakres i podstawę zatrudnienia lub współpracy.
+2. Przez pracę jednakowej wartości rozumie się prace, których wykonywanie wymaga od osób porównywalnych kwalifikacji zawodowych, potwierdzonych dokumentami przewidzianymi w odrębnych przepisach lub praktyką i doświadczeniem zawodowym, a także porównywalnej odpowiedzialności i wysiłku.
+3. Wynagrodzenie, o którym mowa, obejmuje wszystkie składniki wynagrodzenia, bez względu na ich nazwę i charakter, a także inne świadczenia związane z pracą.
+
+### § 8.
+
+1. Organizacja prowadzi działania mające na celu podniesienie świadomości osób zatrudnionych na temat zjawisk przemocy, dyskryminacji, molestowania seksualnego i mobbingu, w szczególności poprzez:
+
+   a) informowanie o przepisach antyprzemocowych, antydyskryminacyjnych i antymobbingowych;
+
+   b) prowadzenie szkoleń dla osób zatrudnionych w zakresie problematyki występowania i zwalczania zjawisk przemocy, dyskryminacji, molestowania seksualnego i mobbingu w miejscu pracy.
+
+## Rozdział III. Obowiązki osób zatrudnionych
+
+### § 10.
+
+Osoby zatrudnione zobowiązane są do powstrzymywania się od zachowań o charakterze przemocy, dyskryminacji, molestowania seksualnego i mobbingu, a także innych niepożądanych zachowań w miejscu pracy, wobec innych osób zatrudnionych i współpracujących, a także do kierowania się zasadą poszanowania godności w tych relacjach.
+
+### § 11.
+
+Osoby wchodzące w skład kadry kierowniczej, mają obowiązek analizowania zachowań zarówno osób którymi zarządzają, jak również współpracujących, pod kątem przestrzegania zasady równego traktowania i przeciwdziałania mobbingowi, przemocy, oraz bezzwłocznego zgłoszenia Organizacji sytuacji, co do której mają podejrzenie, że mogą nosić znamiona przemocy, dyskryminacji, molestowania seksualnego, mobbingu i innych niepożądanych zachowań w miejscu pracy.
+
+## Rozdział IV. Postępowanie wyjaśniające w sprawach o przemoc, dyskryminację, molestowanie seksualne i mobbing oraz tryb składania skarg
+
+### § 12.
+
+1. Każda osoba zatrudniona, która uważa, że doświadczyła jakiejkolwiek formy przemocy, dyskryminacji, molestowania seksualnego, mobbingu lub innych niepożądanych zachowań w miejscu pracy, uprawniona jest do powiadomienia o tym fakcie Organizacji i złożenia skargi do osoby pełniącej funkcję Osoby Zaufania ([zaufanie@jazdow.pl](mailto:zaufanie@jazdow.pl)).
+2. Osobę Zaufania powołuje Zarząd POJ.
+3. Jeśli zgłoszenie, o którym mowa w ust. 1, dotyczy Osoby Zaufania, zgłoszenie należy kierować do jednego z członków/członkiń Zarządu Organizacji.
+4. Skargę zgłasza się na formularzu, który stanowi załącznik do niniejszej Polityki za pomocą poczty elektronicznej na adresy mailowe osób wskazanych w ust. 1 i 2.
+5. Z chwilą złożenia skargi, informacje w niej zawarte mogą być ujawniane wyłącznie osobom biorącym udział w postępowaniu wyjaśniającym.
+6. Skargi anonimowe nie będą rozpatrywane w ramach przedmiotowego postępowania, chyba że okoliczności sprawy będą uprawdopodobnione w stopniu wystarczającym do prowadzenia postępowania wyjaśniającego. Skargi anonimowe mogą stanowić podstawę podejmowanych działań prewencyjnych (np. przeprowadzenie anonimowych ankiet wśród osób zatrudnionych, w sytuacji, gdy zgłoszenie dotyczyło molestowania seksualnego, a następnie zorganizowanie odpowiednich szkoleń).
+7. Wszystkie skargi, w tym anonimowe, są rejestrowane przez Osobę Zaufania.
+8. Osoba Zaufania w szczególnie uzasadnionych przypadkach może samodzielnie wszcząć postępowanie bez skargi, o której mowa w ust. 1, jeżeli:
+
+   a) poweźmie podejrzenie, iż w miejscu pracy z dużym prawdopodobieństwem dochodzi do przemocy, dyskryminacji, molestowania seksualnego, mobbingu;
+
+   b) poweźmie informacje od osoby zatrudnionej, której zgłaszane sytuacje noszące znamiona przemocy, dyskryminacji czy mobbingu bezpośrednio nie dotyczą, ale oceni je jako wysoce prawdopodobne.
+
+### § 13.
+
+1. Osoba Zaufania, każdorazowo w terminie nie dłuższym niż 14 dni od wpłynięcia skargi zwołuje Komisję, której zadaniem jest obiektywne rozpatrzenie zgłoszenia, ustalenie czy zgłoszenie jest zasadne i czy wystąpiło lub występuje zjawisko przemocy, dyskryminacji, w tym molestowania seksualnego, mobbingu lub inne niepożądane zachowanie w miejscu pracy.
+2. W skład Komisji wchodzą następujące osoby:
+
+   a) Osoba Zaufania jako Przewodnicząca/y Komisji;
+
+   b) Osoba zatrudniona w POJ lub osoba współpracująca z POJ, wskazana przez Osobę Zaufania;
+
+   c) Członek/kini Zarządu lub Komisji Rewizyjnej POJ, lub osoba wskazana przez Zarząd POJ;
+
+   d) Opcjonalnie ekspert/ka zewnętrzny zajmujący/a się przeciwdziałaniem przemocy, dyskryminacji, molestowaniu seksualnemu i mobbingowi;
+
+   e) Opcjonalnie osoba zatrudniona w POJ lub osoba współpracująca z POJ, wskazana przez osobę zgłaszającą skargę.
+
+3. Jeśli zgłoszenie dotyczy Osoby Zaufania lub członka/kini Zarządu w skład Komisji zamiast Osoby Zaufania lub członka/kini Zarządu wchodzi osoba z Komisji Rewizyjnej POJ.
+4. Osoba z Komisji Rewizyjnej POJ, która zastępuje Osobę Zaufania pełni jednocześnie funkcję Przewodniczącego/cej Komisji.
+5. W skład Komisji nie może wchodzić osoba, która składa skargę, jak również osoba wskazana w zgłoszeniu jako sprawca/sprawczyni zachowań o charakterze przemocy, dyskryminacji, molestowania seksualnego, mobbingu lub innych nieporządnych zachowań w miejscu pracy.
+6. Członek/kini Komisji obowiązany/a jest przed przystąpieniem do prac złożyć na piśmie zobowiązanie o zachowaniu zasady poufności odnośnie wszystkiego, o czym dowie się w związku z toczącym się postępowaniem.
+7. Strony postępowania oraz osoby występujące w charakterze świadków, zobowiązują się na piśmie, do zachowania zasady poufności, odnośnie wszystkiego, o czym dowiedzą się w związku z toczącym się postępowaniem, do czasu jego zakończenia.
+8. Oświadczenia, o których mowa w ust. 6-7, przechowuje się w aktach sprawy.
+9. Akta sprawy przechowuje Osoba Zaufania w miejscu, do którego nie mają dostępu inne osoby.
+
+### § 14.
+
+1. Komisja rozpoczyna postępowanie bez zbędnej zwłoki, nie później niż w ciągu 14 dni od dnia zwołania. Komisja rozpatruje skargę i przygotowuje dokument „Protokół z przebiegu postępowania wraz z zaleceniami Komisji”, o którym mowa w § 15 w terminie nie dłuższym niż 21 dni. W szczególnie skomplikowanych sprawach Komisja może wydłużyć postępowanie maksymalnie o kolejne 14 dni, informując strony postępowania o przyczynach zaistniałego stanu rzeczy.
+2. Postępowanie przed Komisją prowadzone jest z poszanowaniem praw i ze szczególną dbałością o ochronę dóbr osobistych wszystkich uczestników postępowania.
+3. Komisja decyduje o zakończeniu postępowania bez rozstrzygnięcia merytorycznego, jeżeli:
+
+   a) ustał stosunek pracy bądź inna forma współpracy którejkolwiek ze stron postępowania, chyba że Komisja ustali, że mimo to kontynuowanie postępowania jest możliwe i konieczne dla realizacji obowiązku przeciwdziałania przemocy, dyskryminacji i mobbingowi w organizacji w przyszłości;
+
+   b) o ten sam czyn lub na tej samej podstawie faktycznej toczyło się lub toczy postępowanie przed sądem;
+
+   c) po wstępnej analizie skargi, ocenia skargę za oczywiście bezzasadną.
+
+4. Strony postępowania mają możliwość złożenia wyjaśnień przed Komisją.
+5. Po wysłuchaniu wyjaśnień osoby zgłaszającej skargę, osoby, której stawiane są zarzuty oraz osób wskazanych przez strony, a także po zapoznaniu się z pozostałymi dowodami, Komisja podejmuje decyzję zwykłą większością głosów, co do zasadności rozpatrywanego zgłoszenia.
+6. Wyjaśnienia stron oraz innych osób, z którymi spotyka się Komisja, są protokołowane.
+7. Pod protokołem z każdego spotkania podpisuje się osoba słuchana oraz osoby wchodzące w skład Komisji.
+8. W przypadku odmowy złożenia podpisu przez którąkolwiek ze stron postępowania, fakt ten Komisja odnotowuje w protokole.
+9. W przypadku braku zwykłej większości głosów decyduje głos Przewodniczącego/ej Komisji.
+
+### § 15.
+
+1. Z prac Komisji sporządzany jest dokument „Protokół z przebiegu postępowania wraz z zaleceniami Komisji”, który podpisują wszyscy członkowie/inie Komisji.
+2. Dokument, o którym mowa w ust. 1, sporządzony jest przez wyznaczonego przez Przewodniczącego/cą członka/inię Komisji i zawiera w szczególności:
+
+   a) opis stanu faktycznego stwierdzonego w toku przeprowadzonego postępowania;
+
+   b) stanowisko Komisji w przedmiocie zgłoszenia;
+
+   c) ewentualne zdanie odrębne członka/ini Komisji;
+
+   d) ewentualne proponowane środki zaradcze i dyscyplinujące w stosunku do osoby, która dopuściła się zachowań o charakterze przemocy, dyskryminacji, molestowania seksualnego lub mobbingu;
+
+   e) ewentualne propozycje wsparcia osoby, co do której stwierdzono, iż doświadczyła naruszenia, przy uwzględnieniu okoliczności właściwych dla danego przypadku oraz oceny potrzeb tej osoby;
+
+   f) ewentualne rekomendacje w przedmiocie działań naprawczych do podjęcia przez Organizację, w tym mających zmierzać do skutecznej ochrony dobrostanu w Organizacji w przyszłości.
+
+   g) uzasadnienie nie podjęcia decyzji w przypadku zaistnienia okoliczności, o których mowa w § 14 ust. 3.
+
+2\. Niezwłocznie po zakończeniu postępowania Przewodniczący/a przekazuje zalecenia Komisji do Organizacji.
+
+### § 16.
+
+1. Organizacja, nie później niż w ciągu 14 dni od dnia przekazania przez Przewodniczącego/cą Komisji zaleceń Komisji, podejmuje działania zmierzające do wyeliminowania stwierdzonych nieprawidłowości i przeciwdziała ich powtórzeniu.
+2. W stosunku do osób, wobec których stwierdzono, że dopuściły się przemocy, dyskryminacji, molestowania seksualnego, mobbingu lub innych niepożądanych zachowań w miejscu pracy, Organizacja podejmuje działania dyscyplinujące, które może stanowić w szczególności zakończenie współpracy.
+3. Organizacja, stosując działania dyscyplinujące, kieruje się zasadą proporcjonalności wobec zaistniałego naruszenia.
+4. Przewodniczący/a Komisji jest odpowiedzialny/a za przygotowanie pisemnego komunikatu informującego strony o rezultacie zakończonego postępowania wyjaśniającego.
+
+### § 17.
+
+1. Skorzystanie ze skargi nie może być podstawą niekorzystnego traktowania, a także nie może powodować jakichkolwiek negatywnych konsekwencji dla osoby zgłaszającej skargę oraz osoby/osób ją wspierającej/wspierających.
+2. Odpowiedzialności dyscyplinarnej podlegają osoby, które w ocenie Komisji pomawiają o przemoc, dyskryminację, w tym molestowanie seksualne czy mobbing.
+
+## Rozdział V. Przepisy końcowe
+
+### § 18.
+
+1. Organizacja może wprowadzać zmiany w przedmiotowej Polityce, po konsultacji projektu zmian z osobami zatrudnionymi, w terminie, który daje szansę zabrania głosu możliwie wszystkim osobom zatrudnionym.
+2. Organizacja uwzględnia propozycje osób zatrudnionych zgłoszone w trakcie konsultacji, o których mowa w ust. 1, jeśli można je uznać za obiektywnie racjonalne i wypełniające kryteria efektywnej prewencji antyprzemocowej, antydyskryminacyjnej lub antymobbingowej w miejscu pracy.
+
+### § 19.
+
+Organizacja przy zatrudnianiu nowych osób zobowiązana jest do zapoznania ich z Polityką niezwłocznie po nawiązaniu stosunku pracy lub podjęciu współpracy.


### PR DESCRIPTION
Realizacja trzech wymagań planu Netlify dla projektów open source. Bazuje na #205 (już zmergowanym).

## 1. Licencja z listy OSI — ✅ było, ale niewykrywalne

Wymaganie było spełnione merytorycznie już po #205 (kod na MIT), ale `LICENSE.md` opisuje podział kod/treści i przez to **nie jest rozpoznawany automatycznie** — GitHub i narzędzia skanujące dopasowują plik licencji do wzorca i przy dodatkowej treści oznaczają repo jako „Other". Osoba weryfikująca wniosek może to odczytać jako brak licencji OSI.

Poprawka: doszedł plik **`LICENSE`** z czystym tekstem MIT (GitHub pokaże badge „MIT License"), a `LICENSE.md` odsyła do niego zamiast powielać tekst. Podział pozostaje bez zmian: kod MIT, treści CC BY-NC-SA 4.0 (klauzula NC nie przeszkadza — wymaganie dopuszcza licencję CC „that includes attribution").

## 2. Code of Conduct — ✅ dodane

Rolę kodeksu pełni **Polityka Ochrony Dobrostanu** POJ (przyjęta 26 września 2024 r.), przekazana przez Zarząd:

- `www/polityka-ochrony-dobrostanu.md` — strona serwisu (`/polityka-ochrony-dobrostanu/`)
- link w stopce obok pozostałych `links` — w wersji polskiej „Polityka Ochrony Dobrostanu", w angielskiej „Code of Conduct (PL)"
- `CODE_OF_CONDUCT.md` w katalogu głównym repozytorium — streszczenie, tryb zgłoszeń (`zaufanie@jazdow.pl`) i odesłanie do pełnego tekstu, także po angielsku

Wymaganie Netlify dopuszcza jedną z dwóch dróg (plik w repozytorium **albo** link w nawigacji/stopce) — tu spełnione są obie.

Tekst Polityki przeniesiony bez zmian merytorycznych; poprawione wyłącznie formatowanie eksportu z Google Docs (nagłówki zamiast pogrubień, listy, usunięte puste `**`).

## 3. Link do Netlify — ✅ dodane

„This site is powered by Netlify" w linii licencji w stopce, czyli na wszystkich podstronach, zgodnie z brzmieniem wymagania.

## Korekta numeracji w Polityce (osobny commit)

W dokumencie źródłowym po § 8 następował § 10, a w § 15 dwa ustępy miały numer 2. Na polecenie Zarządu numeracja została uporządkowana:

- § 10 – § 19 przenumerowane na § 9 – § 18
- powtórzony ust. 2 (obecny § 14) poprawiony na ust. 3
- dostosowane dwa odesłania wewnętrzne: „§ 15" → „§ 14" oraz „§ 14 ust. 3" → „§ 13 ust. 3"

Numeracja rozdziałów I – V i treść merytoryczna bez zmian. **Uwaga:** numery paragrafów w wersji publikowanej różnią się teraz od dokumentu przyjętego 26.09.2024 — jeśli Polityka jest cytowana w innych dokumentach organizacji, warto tam zaktualizować odesłania.

## Weryfikacja

Sprawdzone na serwerze deweloperskim:

- `/polityka-ochrony-dobrostanu/` renderuje się (H1, wszystkie rozdziały, `zaufanie@jazdow.pl` jako `mailto:`), konsola bez błędów
- paragrafy renderują się jako ciągła seria § 1 – § 18, a trzy ustępy w § 14 jako 1, 2, 3
- stopka PL: 7 linków, ostatni to Polityka Ochrony Dobrostanu; stopka EN: Privacy Policy + Code of Conduct (PL)
- kliknięcie linku w stopce przenosi na stronę Polityki
- linia licencji zawiera dwa odnośniki: LICENSE.md i netlify.com

## Uwaga redakcyjna

`CODE_OF_CONDUCT.md` zawiera streszczenie, a pełny tekst żyje w `www/polityka-ochrony-dobrostanu.md` (edytowalny przez CMS) — zmiany w Polityce wprowadza się tam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)